### PR TITLE
Upgrade aws provider

### DIFF
--- a/src/app/wait.py
+++ b/src/app/wait.py
@@ -19,7 +19,7 @@ def postgres(db_name, user, host, password):
 
 
 def elastics(es):
-    while(not es.ping()):
+    while not es.ping():
         print("ELASTICSEARCH: waiting for server..", file=sys.stderr)
         time.sleep(1)
 

--- a/terraform/aws/versions.tf
+++ b/terraform/aws/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.70.0"
+      version = "~>4.24"
     }
   }
   cloud {


### PR DESCRIPTION
Attempt to solve `Error: Error creating Elasticsearch domain: InvalidTypeException: Invalid instance type: t3.micro.elasticsearch`