### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -5,6 +5,8 @@ on:
   issues:
     types: [opened, labeled]
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -4,6 +4,10 @@ name: commit
 on:
   push:
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   pylint:
     name: Python lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: "Terraform Deploy"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 ---
 name: Publish NLP Image
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/turnoff.yml
+++ b/.github/workflows/turnoff.yml
@@ -5,6 +5,10 @@ on:
   # schedule:
   #  - cron: '0 23 * * *'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   terraform:
     name: "Turn off Server"

--- a/.github/workflows/turnon.yml
+++ b/.github/workflows/turnon.yml
@@ -1,5 +1,9 @@
 name: "Schedule On"
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   workflow_dispatch:
   # schedule:

--- a/.github/workflows/update_offline.yml
+++ b/.github/workflows/update_offline.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update-s3:
     name: Upload new offline pages to S3 Bucket


### PR DESCRIPTION
Potential fix for [https://github.com/nickumia/world/security/code-scanning/10](https://github.com/nickumia/world/security/code-scanning/10)

Add an explicit top-level `permissions` block in `.github/workflows/commit.yml` so all jobs inherit least-privilege token scopes by default.

Best fix here (without changing existing functionality): set workflow-level permissions to:
- `contents: read` (required for checkout/read access),
- `packages: read` (safe/read-only for package pulls if needed).

This addresses the CodeQL finding while avoiding unnecessary write scopes. Place this block near the top of the workflow (after `on:` is a common location), so it applies to `pylint`, `test`, and `cypress` jobs uniformly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
